### PR TITLE
SIFT patent expires, remove `xfeatures2d`

### DIFF
--- a/mirror_symmetry.py
+++ b/mirror_symmetry.py
@@ -6,7 +6,7 @@ import numpy as np
 import glob
 
 # create SIFT object ((a feature detection algorithm)) 
-sift = cv2.xfeatures2d.SIFT_create()
+sift = cv2.SIFT_create()
 # create BFMatcher object
 bf = cv2.BFMatcher()
 


### PR DESCRIPTION
https://github.com/opencv/opencv/wiki/GSoC_2020#idea-better-sift-in-the-main-repository, So `xfeatures2d` is no longer necessary